### PR TITLE
Writing_Good_Commits.rst: Fix 2nd example typo

### DIFF
--- a/docs/Developers/Writing_Good_Commits.rst
+++ b/docs/Developers/Writing_Good_Commits.rst
@@ -41,7 +41,7 @@ Example of a good commit:
 - `This fixes.. ..whether.`: Describe the reasoning of your changes
    in maximum of 72 characters per line.
 
-- `Closes https://github.com/coala/coala/issues/7971`: Mention the URL
+- `Closes https://github.com/coala/coala/issues/4018`: Mention the URL
    of the issue it closes or fixes.
 
 


### PR DESCRIPTION
This fixes a minor typo and changes it from 7971 --> 4018.

Fixes https://github.com/coala/documentation/issues/573

P.s - I'm a short term contributor but tried to follow the guidelines as I could.